### PR TITLE
WS2-1380: Fix error with fields still being required although they were hidden

### DIFF
--- a/src/Plugin/Block/AsuFooterBlock.php
+++ b/src/Plugin/Block/AsuFooterBlock.php
@@ -402,7 +402,6 @@ class AsuFooterBlock extends BlockBase {
           '#type' => 'textfield',
           '#title' => $this->t('Menu title'),
           '#default_value' => $config[$title_id] ?? '',
-          '#required' => true,
           '#description' => $this->t('Leaving this blank will prevent the form from submitting.'),
           '#states' => [
             'visible' => [
@@ -410,6 +409,12 @@ class AsuFooterBlock extends BlockBase {
             ],
             'disabled' => [
               ":input[name='settings[{$index}_column][asu_footer_block_menu_{$index}_column_name{$name_suffix}]']" => ['value' => '_none'],
+              ':input[name="settings[asu_footer_block_show_columns]"]' => ['checked' => false],
+            ],
+            'required' => [
+              ':input[name="settings[asu_footer_block_show_columns]"]' => [
+                'checked' => true,
+              ],
             ],
           ]
         ];

--- a/src/Plugin/Block/AsuFooterBlock.php
+++ b/src/Plugin/Block/AsuFooterBlock.php
@@ -407,14 +407,8 @@ class AsuFooterBlock extends BlockBase {
             'visible' => [
               ":input[name='settings[{$index}_column][asu_footer_block_menu_{$index}_column_name{$name_suffix}]']" => ['!value' => '_none'],
             ],
-            'disabled' => [
-              ":input[name='settings[{$index}_column][asu_footer_block_menu_{$index}_column_name{$name_suffix}]']" => ['value' => '_none'],
-              ':input[name="settings[asu_footer_block_show_columns]"]' => ['checked' => false],
-            ],
             'required' => [
-              ':input[name="settings[asu_footer_block_show_columns]"]' => [
-                'checked' => true,
-              ],
+              ":input[name='settings[{$index}_column][asu_footer_block_menu_{$index}_column_name{$name_suffix}]']" => ['!value' => '_none'],
             ],
           ]
         ];


### PR DESCRIPTION
In testing, it was found that on new installs the Menu Title fields were still being read to be required even though they were hidden from view. Updated the code to adjust when these field become required.